### PR TITLE
Add Palliative Care page and section details

### DIFF
--- a/src/components/home/PalliativeCareSection.jsx
+++ b/src/components/home/PalliativeCareSection.jsx
@@ -200,6 +200,32 @@ const PalliativeCareSection = () => {
                   of conventional treatments, and improve overall quality of
                   life.
                 </p>
+                <p className="text-gray-600 mt-4">
+                  According to
+                  {" "}
+                  <a
+                    href="https://palliativeorg.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary underline"
+                  >
+                    palliativeorg.com
+                  </a>
+                  , palliative care focuses on relieving symptoms and stress so
+                  patients and families can enjoy the best possible quality of
+                  life during treatment.
+                </p>
+                <p className="text-gray-600 mt-4">
+                  The site explains that an interdisciplinary team of doctors,
+                  nurses, and other specialists works alongside a patient's
+                  regular physicians to provide an extra layer of support.
+                </p>
+                <p className="text-gray-600 mt-4 mb-6">
+                  Palliative care can be started at any stage of a serious
+                  illness and may include help with pain management, guidance on
+                  treatment choices, and emotional or spiritual support for both
+                  patient and family members.
+                </p>
 
                 <div className="mt-6">
                   <AppointmentButton

--- a/src/pages/palliative-care.js
+++ b/src/pages/palliative-care.js
@@ -1,0 +1,62 @@
+import React from "react";
+import Layout from "../components/layout/Layout";
+import PalliativeCareSection from "../components/home/PalliativeCareSection";
+
+const PalliativeCarePage = () => {
+  return (
+    <Layout title="Palliative Care | Dr. Selvan's Homeopathy">
+      {/* Hero Section */}
+      <div className="bg-gradient-to-b from-blue-50 to-white py-12 md:py-16">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center max-w-3xl mx-auto">
+            <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-4">
+              Palliative <span className="text-primary">Care</span>
+            </h1>
+            <p className="text-lg text-gray-600 italic">
+              "Compassionate support when you need it most"
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Introductory Content */}
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <section className="mb-12">
+          <h2 className="text-2xl md:text-3xl font-bold text-gray-900 mb-6">
+            What Is <span className="text-primary">Palliative Care?</span>
+          </h2>
+          <p className="text-gray-700 mb-4 leading-relaxed">
+            According to
+            {" "}
+            <a
+              href="https://palliativeorg.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary underline"
+            >
+              palliativeorg.com
+            </a>
+            , palliative care is specialized medical care for people living with
+            serious illness. It focuses on relieving symptoms and stress so both
+            patients and their families can enjoy the best possible quality of
+            life.
+          </p>
+          <p className="text-gray-700 mb-4 leading-relaxed">
+            This care is provided by a team of doctors, nurses, and other
+            specialists who work together with a patient's regular physicians to
+            offer an extra layer of support at any stage of illness.
+          </p>
+          <p className="text-gray-700 leading-relaxed">
+            Services often include pain and symptom management, help navigating
+            treatment options, and emotional or spiritual support for everyone
+            involved.
+          </p>
+        </section>
+      </div>
+
+      <PalliativeCareSection />
+    </Layout>
+  );
+};
+
+export default PalliativeCarePage;


### PR DESCRIPTION
## Summary
- expand PalliativeCareSection with overview paragraphs and external link
- create dedicated `palliative-care` page with hero section and intro text

## Testing
- `npm run lint` *(fails: ESLint couldn't find config "next/typescript")*